### PR TITLE
Set default download location to script working path

### DIFF
--- a/ydl-test.py
+++ b/ydl-test.py
@@ -1,40 +1,37 @@
 from __future__ import unicode_literals
 import youtube_dl
+import os
 
 
 def grab(link):
-    path = (input("Where do you want to download it:"))
-    while len(path) == 0:
-        path =(input("Please select a directory:"))
+    path = (input("Where do you want to download it: "))
+    
+    if len(path) > 0:
+        path =(input("Please select a directory: "))
     else:
-        pass
+        path = os.getcwd()
+        
     ydl_opts = {
     'format': 'bestaudio/best',
     'outtmpl': f'{path}\%(title)s.%(ext)s',  #path will be defined on main.py
     #'simulate' : True,    #only here for testing
     'default_search' : 'auto',
     'postprocessors': [{
-        'key': 'FFmpegExtractAudio',     
+        'key': 'FFmpegExtractAudio',
         'preferredcodec': 'mp3',
         'preferredquality': '192',
     }],
     }
     with youtube_dl.YoutubeDL(ydl_opts) as ydl:
         ydl.download([link])
-    return		
+    return
 
 
-
-url = input("Search for a song or enter a link:")
+url = input("Search for a song or enter a link: ")
 
 while len(url) == 0:
     
     print ("No url entered")
     url = input("Please enter a URL")
-    
-else:
-    grab(url)
-    
-    
-        
-    
+
+grab(url)


### PR DESCRIPTION
Downloads to working dir if no path provided, fixed input prompts (added a spaces.) Removed unnecessary else statement.